### PR TITLE
Add “gallery_items” attribute to PageSerializer

### DIFF
--- a/mezzanine_api/__init__.py
+++ b/mezzanine_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.6.0dev1'
+__version__ = '0.5.0'
 default_app_config = 'mezzanine_api.apps.MezzanineAPIAppConfig'

--- a/mezzanine_api/__init__.py
+++ b/mezzanine_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.0'
+__version__ = '0.6.0dev1'
 default_app_config = 'mezzanine_api.apps.MezzanineAPIAppConfig'

--- a/mezzanine_api/serializers.py
+++ b/mezzanine_api/serializers.py
@@ -82,6 +82,7 @@ class PageSerializer(serializers.ModelSerializer):
     content = serializers.SerializerMethodField('get_page_content')
     meta_description = serializers.CharField(source='description', read_only=True)
     tags = serializers.CharField(source='keywords_string', read_only=True)
+    gallery_items = serializers.SerializerMethodField('get_gallery_content')
 
     def get_page_content(self, obj):
         if obj.content_model == 'richtextpage':
@@ -91,10 +92,18 @@ class PageSerializer(serializers.ModelSerializer):
         else:
             return None
 
+    def get_gallery_content(self, obj):
+        items = []
+        if hasattr(obj, 'gallery'):
+            for item in obj.gallery.images.values():
+                item['url'] = settings.MEDIA_URL + item['file']
+                items.append(item)
+        return items
+
     class Meta:
         model = Page
         fields = ('id', 'parent', 'title', 'content', 'content_model', 'slug', 'publish_date',
-                  'login_required', 'meta_description', 'tags')
+                  'login_required', 'meta_description', 'tags', 'gallery_items')
 
 
 class PostCreateSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Dear George,

first things first: Thanks for this great add-on to Mezzanine, it was really helpful for our current project. However, we required mezzanine-api to expose the contents of a page gallery over the JSON API. This PR tries to do it in a minimalistic way, all bugs and shortcomings are belong to us.

With kind regards,
Andreas.