### PR TITLE
Remove lookup_type param from views so it will be valid to mezzanine …

### DIFF
--- a/mezzanine_api/views.py
+++ b/mezzanine_api/views.py
@@ -34,7 +34,7 @@ class UserFilter(django_filters.FilterSet):
     """
     A class for filtering users.
     """
-    username = django_filters.CharFilter(name="username", lookup_type='istartswith')
+    username = django_filters.CharFilter(name="username")
 
     class Meta:
         model = User
@@ -126,13 +126,13 @@ class PostFilter(django_filters.FilterSet):
     A class for filtering blog posts.
     """
     category_id = django_filters.NumberFilter(name="categories__id")
-    category_name = django_filters.CharFilter(name="categories__title", lookup_type='contains')
-    category_slug = django_filters.CharFilter(name="categories__slug", lookup_type='exact')
-    tag = django_filters.CharFilter(name='keywords_string', lookup_type='contains')
+    category_name = django_filters.CharFilter(name="categories__title")
+    category_slug = django_filters.CharFilter(name="categories__slug")
+    tag = django_filters.CharFilter(name='keywords_string')
     author_id = django_filters.NumberFilter(name="user__id")
-    author_name = django_filters.CharFilter(name="user__username", lookup_type='istartswith')
-    date_min = django_filters.DateFilter(name='publish_date', lookup_type='gte')
-    date_max = django_filters.DateFilter(name='publish_date', lookup_type='lte')
+    author_name = django_filters.CharFilter(name="user__username")
+    date_min = django_filters.DateFilter(name='publish_date')
+    date_max = django_filters.DateFilter(name='publish_date')
 
     class Meta:
         model = Post


### PR DESCRIPTION
mezzanine version 4.22 not compliance with the lookup_type parameter that we pass along with the request. i've removed it and now the api works as it suppose to (also via swager).