### PR TITLE
Add support for custom user models

### DIFF
--- a/mezzanine_api/serializers.py
+++ b/mezzanine_api/serializers.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import NoReverseMatch
 from django.template.defaultfilters import strip_tags
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 
 from mezzanine.blog.models import BlogPost as Post, BlogCategory
@@ -10,6 +10,9 @@ from mezzanine.conf import settings
 from mezzanine.utils.sites import current_request
 
 from rest_framework import serializers
+
+# Supports custom user models
+User = get_user_model()
 
 
 class PrivateField(serializers.ReadOnlyField):

--- a/mezzanine_api/views.py
+++ b/mezzanine_api/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from mezzanine.blog.models import BlogPost as Post, BlogCategory
 from mezzanine.pages.models import Page
@@ -12,6 +12,9 @@ from .serializers import PostCreateSerializer, PostUpdateSerializer, PostOutputS
 from .permissions import IsAdminOrReadOnly
 from .pagination import MezzaninePagination, PostPagination
 from .mixins import PutUpdateModelMixin
+
+# Supports custom user models
+User = get_user_model()
 
 
 class ListViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
I have defined a custom user model in my project using:
`django.contrib.auth.models.AbstractUser` 
and 
`AUTH_USER_MODEL = 'myapp.User'`

I discovered mezzanine_api isn't compatible with this:
`AttributeError: Manager isn't available; 'auth.User' has been swapped for 'myapp.User'
`
Hence the update according to [documentation](https://docs.djangoproject.com/en/2.0/topics/auth/customizing/#referencing-the-user-model)