### PR TITLE
add support for django-oauth-toolkit version 1.1.2

### DIFF
--- a/mezzanine_api/settings.py
+++ b/mezzanine_api/settings.py
@@ -32,7 +32,7 @@ The <a href="http://gcushen.github.io/mezzanine-api/client/" target="_blank">API
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'django-rest-swagger>=2.1.1, <3.0.0',
         'djangorestframework>=3.7.1, <4.0.0',
         'django-filter>=1.1.0, <2.0.0',
-        'django-oauth-toolkit>=0.12.0, <1.0.0',
+        'django-oauth-toolkit>=1.1.2, <1.2.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I believe this will add support for django-oauth-toolkit version 1.1.2.

I'm still in the process of learning to work with oauth2, so I haven't fully tested it yet.

Will probably be able to confirm whether it works in a couple of weeks
